### PR TITLE
issue #24: fix regex pattern

### DIFF
--- a/finesse/accuracy_functions.py
+++ b/finesse/accuracy_functions.py
@@ -27,23 +27,23 @@ def calculate_accuracy(responses_url: list[str], expected_url: list | str) -> Ac
     position: int = 0
     total_pages: int = len(responses_url)
     score: float = 0.0
-    expected_number = []
+    expected_url_ids = []
 
-    PATTERN = r'/(\d+)/'
+    PATTERN = r'/[a-z]{3}/\d+/\d+'
     if isinstance(expected_url, list):
         for url in expected_url:
             if url.startswith("https://inspection.canada.ca"):
-                number = int(re.findall(PATTERN, url)[0])
-                expected_number.append(number)
+                url_id = re.findall(PATTERN, url)[0]
+                expected_url_ids.append(url_id)
     elif isinstance(expected_url, str) and expected_url.startswith("https://inspection.canada.ca"):
-        number = int(re.findall(PATTERN, expected_url)[0])
-        expected_number.append(number)
+        url_id = re.findall(PATTERN, expected_url)[0]
+        expected_url_ids.append(url_id)
 
     for idx, response_url in enumerate(responses_url):
         if response_url.startswith("https://inspection.canada.ca"):
             try:
-                response_number = int(re.findall(PATTERN, response_url)[0])
-                if response_number in expected_number:
+                response_url_id = re.findall(PATTERN, response_url)[0]
+                if response_url_id in expected_url_ids:
                     position = idx
                     score = 1 - (position / total_pages)
                     score= round(score, 2)

--- a/tests/test_accuracy_functions.py
+++ b/tests/test_accuracy_functions.py
@@ -34,5 +34,33 @@ class TestFunctions(unittest.TestCase):
         self.assertEqual(result.total_pages, 4)
         self.assertEqual(result.score, 0.5)
 
+    def test_calculate_accuracy_no_match(self):
+        responses_url = [
+            "https://inspection.canada.ca/exporting-food-plants-or-animals/food-exports/food-specific-export-requirements/meat/crfpcp/eng/1434119937443/1434120400252",
+            "https://inspection.canada.ca/protection-des-vegetaux/especes-envahissantes/directives/date/d-08-04/fra/1323752901318/1323753612811",
+            "https://inspection.canada.ca/varietes-vegetales/vegetaux-a-caracteres-nouveaux/demandeurs/directive-94-08/documents-sur-la-biologie/lens-culinaris-medikus-lentille-/fra/1330978380871/1330978449837",
+            "https://inspection.canada.ca/protection-des-vegetaux/especes-envahissantes/directives/date/d-96-15/fra/1323854808025/1323854941807"
+        ]
+        expected_url = "https://inspection.canada.ca/animal-health/terrestrial-animals/exports/pets/brunei-darussalam/eng/1475849543824/1475849672294"
+        result = calculate_accuracy(responses_url, expected_url)
+        self.assertEqual(result.position, 0)
+        self.assertEqual(result.total_pages, 4)
+        self.assertEqual(result.score, 0.0)
+
+    def test_calculate_accuracy_with_query_params(self):
+        responses_url = [
+            "https://inspection.canada.ca/exporting-food-plants-or-animals/food-exports/food-specific-export-requirements/meat/crfpcp/eng/1434119937443/1434120400252?param1=value1&param2=value2",
+            "https://inspection.canada.ca/protection-des-vegetaux/especes-envahissantes/directives/date/d-08-04/fra/1323752901318/1323753612811?param3=value3",
+            "https://inspection.canada.ca/varietes-vegetales/vegetaux-a-caracteres-nouveaux/demandeurs/directive-94-08/documents-sur-la-biologie/lens-culinaris-medikus-lentille-/fra/1330978380871/1330978449837?param4=value4",
+            "https://inspection.canada.ca/protection-des-vegetaux/especes-envahissantes/directives/date/d-96-15/fra/1323854808025/1323854941807?param5=value5"
+        ]
+        expected_url = "https://inspection.canada.ca/protection-des-vegetaux/especes-envahissantes/directives/date/d-08-04/fra/1323752901318/1323753612811?param3=value3"
+        result = calculate_accuracy(responses_url, expected_url)
+        self.assertEqual(result.position, 1)
+        self.assertEqual(result.total_pages, 4)
+        self.assertEqual(result.score, 0.75)
+
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#24
- [x] match the pattern anywhere in the URL

This avoids missing cases like `/eng/1630326254350/1630326374266?chap=5#a12_7`